### PR TITLE
docs: add codecov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Trustworthy orchestration for LLM-powered agents. Predictable routing. Immutable state. Single termination enforced.
 
+[![codecov](https://codecov.io/gh/consent-ai/ClearFlow/graph/badge.svg)](https://codecov.io/gh/consent-ai/ClearFlow)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
 


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file. It adds a Codecov badge to display code coverage metrics for the project.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R5): Added a Codecov badge to provide visibility into the project's code coverage.