### PR TITLE
fix: remove codecov badge and enforce upload success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,9 +161,9 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         files: ./coverage.xml
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
-      continue-on-error: true
+        verbose: true
 
 
   build:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Trustworthy orchestration for LLM-powered agents. Predictable routing. Immutable state. Single termination enforced.
 
-[![codecov](https://codecov.io/gh/consent-ai/ClearFlow/graph/badge.svg)](https://codecov.io/gh/consent-ai/ClearFlow)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.13+](https://img.shields.io/badge/python-3.13+-blue.svg)](https://www.python.org/downloads/)
 


### PR DESCRIPTION
- Remove codecov badge until integration is working
- Change fail_ci_if_error to true to catch upload failures
- Add verbose flag for better debugging
- Remove continue-on-error to ensure failures are visible