### PR TITLE
ci: automated release management with GitVersion and Release Drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,89 @@
+# .github/release-drafter.yml
+
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feat'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+  - title: '🧹 Chores'
+    labels:
+      - 'chore'
+  - title: '📚 Documentation'
+    labels:
+      - 'docs'
+  - title: '💅 Styles'
+    labels:
+      - 'style'
+  - title: '♻️ Refactoring'
+    labels:
+      - 'refactor'
+  - title: '⚡️ Performance'
+    labels:
+      - 'perf'
+  - title: '🧪 Tests'
+    labels:
+      - 'test'
+  - title: '🏗️ Build'
+    labels:
+      - 'build'
+  - title: '🔄 CI'
+    labels:
+      - 'ci'
+  - title: '↩️ Revert'
+    labels:
+      - 'revert'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## What's Changed
+
+  $CHANGES
+autolabeler:
+  - label: 'feat'
+    title:
+      - '/^feat(\([^)]+\))?:/i'
+  - label: 'fix'
+    title:
+      - '/^fix(\([^)]+\))?:/i'
+  - label: 'chore'
+    title:
+      - '/^chore(\([^)]+\))?:/i'
+  - label: 'docs'
+    title:
+      - '/^docs(\([^)]+\))?:/i'
+  - label: 'style'
+    title:
+      - '/^style(\([^)]+\))?:/i'
+  - label: 'refactor'
+    title:
+      - '/^refactor(\([^)]+\))?:/i'
+  - label: 'perf'
+    title:
+      - '/^perf(\([^)]+\))?:/i'
+  - label: 'test'
+    title:
+      - '/^test(\([^)]+\))?:/i'
+  - label: 'build'
+    title:
+      - '/^build(\([^)]+\))?:/i'
+  - label: 'ci'
+    title:
+      - '/^ci(\([^)]+\))?:/i'
+  - label: 'revert'
+    title:
+      - '/^revert(\([^)]+\))?:/i'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,22 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
 
 env:
@@ -36,16 +33,10 @@ jobs:
       id: gitversion
       uses: gittools/actions/gitversion/execute@v4
         
-    - name: Validate tag matches version
-      if: startsWith(github.ref, 'refs/tags/')
+    - name: Display calculated version
       run: |
-        TAG_VERSION=${GITHUB_REF#refs/tags/v}
-        CALCULATED_VERSION=${{ steps.gitversion.outputs.majorMinorPatch }}
-        if [ "$TAG_VERSION" != "$CALCULATED_VERSION" ]; then
-          echo "::error::Tag version ($TAG_VERSION) does not match calculated version ($CALCULATED_VERSION)"
-          exit 1
-        fi
-        echo "Tag version matches calculated version: $CALCULATED_VERSION"
+        echo "Calculated version: ${{ steps.gitversion.outputs.majorMinorPatch }}"
+        echo "SemVer: ${{ steps.gitversion.outputs.semVer }}"
 
   build-and-publish:
     name: Build and Publish
@@ -84,17 +75,42 @@ jobs:
       run: |
         ls -la dist/
         
+    - name: Get draft release
+      id: draft
+      run: |
+        DRAFT_RELEASE=$(gh release list --draft --json tagName,id --jq '.[0]')
+        if [ -z "$DRAFT_RELEASE" ]; then
+          echo "::error::No draft release found. Please ensure Release Drafter has created a draft."
+          exit 1
+        fi
+        echo "draft_id=$(echo $DRAFT_RELEASE | jq -r .id)" >> $GITHUB_OUTPUT
+        echo "Found draft release: $(echo $DRAFT_RELEASE | jq -r .tagName)"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Create and push tag
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        TAG="v${{ needs.version.outputs.versionTag }}"
+        git tag -a "$TAG" -m "Release $TAG"
+        git push origin "$TAG"
+        
     - name: Publish to PyPI
-      if: startsWith(github.ref, 'refs/tags/')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         skip-existing: true
         
-    - name: Create GitHub Release
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: softprops/action-gh-release@v2
-      with:
-        files: dist/*
-        generate_release_notes: true
-        draft: false
-        prerelease: false
+    - name: Publish GitHub Release
+      run: |
+        # Update draft with correct tag and publish it
+        gh release edit ${{ steps.draft.outputs.draft_id }} \
+          --tag "v${{ needs.version.outputs.versionTag }}" \
+          --title "v${{ needs.version.outputs.versionTag }}" \
+          --draft=false \
+          --latest
+        
+        # Upload built artifacts to the release
+        gh release upload "v${{ needs.version.outputs.versionTag }}" dist/* --clobber
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Configure Release Drafter to maintain draft releases with categorized changelogs
- Update release workflow to use manual dispatch only for predictable versioning
- Setup for trusted PyPI publishing with pending publisher

## Changes
- Added `.github/release-drafter.yml` configuration for changelog generation
- Added `.github/workflows/release-drafter.yml` to update draft on PR merges
- Modified `.github/workflows/release.yml` to:
  - Remove tag trigger, use manual dispatch only
  - Find and publish existing draft release
  - Create tags automatically with GitVersion-calculated version

## Test Plan
- [x] Commit and push changes
- [ ] Create and merge PR to trigger Release Drafter
- [ ] Verify draft release is created
- [ ] Run release workflow manually
- [ ] Verify PyPI publication and GitHub release

🤖 Generated with [Claude Code](https://claude.ai/code)