### PR TITLE
ci: integrate GitVersion with Release Drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,8 @@
 # .github/release-drafter.yml
 
-name-template: 'v$RESOLVED_VERSION'
-tag-template: 'v$RESOLVED_VERSION'
+# Version is provided by GitVersion in the workflow
+name-template: '$INPUT_NAME'
+tag-template: '$INPUT_TAG'
 categories:
   - title: '🚀 Features'
     labels:
@@ -38,17 +39,7 @@ categories:
       - 'revert'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
+# Version resolver removed - GitVersion handles versioning
 template: |
   ## What's Changed
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,6 +17,25 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for GitVersion
+          
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v4
+        with:
+          versionSpec: '6.x'
+          
+      - name: Calculate version
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v4
+        
+      - name: Update Release Draft
+        uses: release-drafter/release-drafter@v6
+        with:
+          version: ${{ steps.gitversion.outputs.majorMinorPatch }}
+          name: v${{ steps.gitversion.outputs.majorMinorPatch }}
+          tag: v${{ steps.gitversion.outputs.majorMinorPatch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Integrate GitVersion with Release Drafter for consistent versioning
- Remove manual version resolution from Release Drafter config

## Changes
- Updated `.github/workflows/release-drafter.yml` to calculate version with GitVersion
- Pass calculated version to Release Drafter via `version`, `name`, and `tag` parameters
- Updated `.github/release-drafter.yml` to use `$INPUT_NAME` and `$INPUT_TAG` templates
- Removed `version-resolver` from config since GitVersion handles versioning

## Benefits
- Single source of truth for versioning (GitVersion)
- Consistent version across draft releases and actual releases
- Prevents version mismatch between Release Drafter and release workflow

## Test Plan
- [x] Create PR
- [ ] Verify Release Drafter runs with GitVersion
- [ ] Check draft release has correct version from GitVersion