### PR TITLE
docs: fix Claude Code integration syntax and remove documentation duplication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,9 +277,8 @@ ClearFlow includes comprehensive llms.txt support for optimal AI assistant integ
    - Use GitHub raw URLs (we have no separate website)
 
 3. **Integration**:
+   - See README.md for Claude Code setup instructions
    - Direct URLs work with any llms.txt-compatible tool
-   - Use mcpdoc for IDE integration: `mcpdoc --urls ClearFlow:https://raw.githubusercontent.com/artificial-sapience/clearflow/main/llms.txt`
-   - See [mcpdoc documentation](https://github.com/langchain-ai/mcpdoc) for IDE-specific setup
 
 4. **Maintenance**:
    - Manual generation: `uv run python scripts/generate_llms_txt_files.py`

--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ ClearFlow provides comprehensive documentation in [llms.txt](https://llmstxt.org
 Add ClearFlow documentation to Claude Code with one command:
 
 ```bash
-claude mcp add mcpdoc --urls ClearFlow:https://raw.githubusercontent.com/artificial-sapience/clearflow/main/llms.txt
+claude mcp add-json clearflow-docs '{
+    "type":"stdio",
+    "command":"uvx",
+    "args":["--from", "mcpdoc", "mcpdoc", "--urls", "ClearFlow:https://raw.githubusercontent.com/artificial-sapience/clearflow/main/llms.txt"]
+}'
 ```
 
 For IDEs (Cursor, Windsurf), see the [mcpdoc documentation](https://github.com/langchain-ai/mcpdoc#configuration).


### PR DESCRIPTION
## Summary
- Fixes Claude Code integration command syntax in README.md using correct `claude mcp add-json` format
- Removes duplicate documentation from CLAUDE.md to maintain DRY principles
- CLAUDE.md now references README.md for user-facing setup instructions

## Test plan
- [x] Verified correct mcpdoc syntax from official documentation
- [x] Updated README.md with working command format
- [x] Removed duplication while maintaining clear reference path
- [x] All quality checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)