### PR TITLE
feat: add Python 3.10+ compatibility while maintaining strict quality standards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     
     steps:
     - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/artificial-sapience/clearflow/badge.svg?branch=main)](https://coveralls.io/github/artificial-sapience/clearflow?branch=main)
 [![PyPI](https://badge.fury.io/py/clearflow.svg)](https://pypi.org/project/clearflow/)
 [![PyPI Downloads](https://static.pepy.tech/personalized-badge/clearflow?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/clearflow)
-![Python](https://img.shields.io/badge/Python-3.13%2B-blue)
+[![Python versions](https://img.shields.io/pypi/pyversions/clearflow.svg)](https://pypi.org/project/clearflow/)
 ![License](https://img.shields.io/badge/License-MIT-yellow)
 [![llms.txt](https://img.shields.io/badge/llms.txt-green)](https://raw.githubusercontent.com/artificial-sapience/clearflow/main/llms.txt)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ maintainers = [
 ]
 license = "MIT"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.10"
 
 keywords = [
     "language-models", "ai-agents", "orchestration", "agents", "async", 
@@ -29,6 +29,9 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Application Frameworks",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering :: Information Analysis",
@@ -117,7 +120,7 @@ include = [
 #################################### Ruff Configuration ####################################
 [tool.ruff]
 line-length = 120
-target-version = "py313"
+target-version = "py310"
 indent-width = 4
 preview = true
 fix = true
@@ -269,7 +272,7 @@ check-typed-exception = true
 #################################### Pyright Configuration ####################################
 [tool.pyright]
 typeCheckingMode = "strict"
-pythonVersion = "3.13"
+pythonVersion = "3.10"
 include = ["clearflow", "tests", "examples", "linters", "scripts"]
 exclude = ["**/__pycache__", "**/.venv", "**/venv", ".venv"]
 stubPath = "typings"  # Use our DSPy type stubs


### PR DESCRIPTION
## Summary
Expands Python version support from 3.13+ to 3.10+ to increase ClearFlow's accessibility while maintaining all quality standards.

## Changes Made
- **📦 pyproject.toml**: Updated `requires-python` from `>=3.13` to `>=3.10`
- **🏷️ PyPI classifiers**: Added Python 3.10, 3.11, 3.12 support  
- **🔧 Tool configuration**: Updated Ruff and Pyright to target Python 3.10 (oldest supported)
- **📋 README badge**: Replaced static badge with dynamic PyPI versions badge (like Pydantic)
- **🧪 CI matrix**: Added testing across Python 3.10-3.13 on all platforms (Ubuntu, macOS, Windows)

## Quality Standards Preserved
✅ **Zero dependencies** - No external library compatibility concerns  
✅ **100% test coverage** - Required across all Python versions  
✅ **Strict linting** - All Ruff rules remain identical  
✅ **Type safety** - Pyright strict mode checking against Python 3.10  
✅ **Custom linters** - Architecture, immutability, test compliance unchanged  
✅ **Security scanning** - Bandit, pip-audit work identically  
✅ **Complexity limits** - Grade A requirements preserved  

## Benefits
- **📈 Larger user base**: Python 3.10-3.12 widely deployed in production
- **🏢 Enterprise compatibility**: Organizations often conservative with Python upgrades  
- **⚡ CI/CD flexibility**: Works in more environments without requiring cutting-edge Python
- **🔄 Dynamic badge**: PyPI versions badge automatically updates when new Python versions are added

## Testing Strategy
- CI now tests all combinations: 4 Python versions × 3 operating systems = 12 test jobs
- Type checking against oldest supported version ensures forward compatibility
- Quality standards enforced identically across all versions

🤖 Generated with [Claude Code](https://claude.ai/code)